### PR TITLE
XSD Support in VSCode Xml Extension

### DIFF
--- a/vscode-plugin/synapse-schemas/synapse_config.xsd
+++ b/vscode-plugin/synapse-schemas/synapse_config.xsd
@@ -35,6 +35,7 @@
     <xs:include schemaLocation="task.xsd" />
     <xs:include schemaLocation="template.xsd" />
     <xs:include schemaLocation="registry.xsd" />
+    <xs:include schemaLocation="mediators/mediators.xsd" />
 
     <xs:element name="definitions" type="Definition">
         <xs:annotation>
@@ -68,4 +69,3 @@
         </xs:choice>
     </xs:complexType>
 </xs:schema>
-


### PR DESCRIPTION
## Purpose

Includes the mediator xsd at the top level because otherwise the vscode xml extension would not download the mediators XSDs resulting in no support for any mediator, e.g. payload factory, log, filter.