### PR TITLE
Endpoint in Call mediator Must not be Specified

### DIFF
--- a/vscode-plugin/synapse-schemas/mediators/core/call.xsd
+++ b/vscode-plugin/synapse-schemas/mediators/core/call.xsd
@@ -63,7 +63,7 @@
                         </xs:attribute>
                     </xs:complexType>
                 </xs:element>
-                <xs:element name="endpoint" type="NamedEndpoint" minOccurs="1" maxOccurs="1" />
+                <xs:element name="endpoint" type="NamedEndpoint" minOccurs="0" maxOccurs="1" />
             </xs:all>
             <xs:attribute name="blocking" type="xs:boolean" use="optional" default="true" />
             <xs:attribute name="description" type="xs:string" use="optional" />
@@ -71,4 +71,3 @@
     </xs:element>
 
 </xs:schema>
-


### PR DESCRIPTION
## Purpose

Do not throw an error for the valid `<call />` because if the endpoint is not specified then the message is sent to the address in the `wsa:To` header value.
